### PR TITLE
Fix action location

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Clone PR branch
         uses: actions/checkout@v2
       - name: Create release
-        uses: ./.github/actions/pr-release-action
+        uses: ./
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prerelease_id: "rc"


### PR DESCRIPTION
The copied workflow script contained the wrong path, now the action definition is located on the root of the repository