### PR TITLE
Allow whitespace in prerelease command

### DIFF
--- a/src/pr-release.js
+++ b/src/pr-release.js
@@ -18,7 +18,8 @@ async function run() {
         return;
       }
     } else if (["created", "edited"].includes(context.payload.action)) {
-      if (context.payload["comment"]["body"] === "/prerelease") {
+      const comment = context.payload["comment"]["body"];
+      if (comment && comment.trim() === "/prerelease") {
         prerelease = true;
         const pr = await getPR();
         commitSha = pr.data.head.sha;

--- a/tests/pr-release.test.js
+++ b/tests/pr-release.test.js
@@ -84,7 +84,7 @@ test("Create release", async () => {
 test("Create prerelease", async () => {
   context.payload = {
     action: "created",
-    comment: { body: "/prerelease", id: "comment_id" },
+    comment: { body: "/prerelease ", id: "comment_id" },
   };
   getPR.mockReturnValueOnce(
     Promise.resolve({


### PR DESCRIPTION
Fixes a bug where the prerelease command didn't work it the user accidentally added any whitespace characters. 