### PR TITLE
Allow dry run for other PR events

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ jobs:
           prerelease_id: "rc"
 ```
 
+If you use the `dry_run` option then the workflow can also run on other pull request events than `closed`. In this case only the bump level and new version number are outputted. This lets you check whether a new release would be created or not for pull request events such as `synchronize` or `labeled` and use the outputs in the next steps.
+
 ## Inputs
 
 | name              | required | description |

--- a/src/pr-release.js
+++ b/src/pr-release.js
@@ -9,6 +9,7 @@ const { addComment, addCommentReaction } = require("./comment");
 async function run() {
   try {
     let prerelease = false;
+    let dry_run = core.getInput("dry_run") === "true";
     let commitSha = null;
     if (context.payload.action === "closed") {
       const pr = await getPR();
@@ -27,11 +28,13 @@ async function run() {
       } else {
         return;
       }
+    } else if (dry_run) {
+      await getNextVersion(false);
+      return;
     } else {
       console.log(`Action ${context.payload.action} not supported`);
       return;
     }
-
     // Check version
     const version = await getNextVersion(prerelease);
     if (!version) {
@@ -43,7 +46,7 @@ async function run() {
     const releaseData = await createReleaseData();
 
     // Create release
-    if (core.getInput("dry_run") !== "true") {
+    if (!dry_run) {
       console.log("Create release");
       const release = await createRelease(
         version.toString(),

--- a/src/version.js
+++ b/src/version.js
@@ -45,6 +45,8 @@ async function getNextVersion(prerelease) {
   }
   const bump = await getBumpLevel(commitMessages, prerelease);
   if (!bump) {
+    core.setOutput("version", null);
+    core.setOutput("bump", null);
     return null;
   }
   console.log(`Bumping with ${bump}`);

--- a/tests/pr-release.test.js
+++ b/tests/pr-release.test.js
@@ -81,6 +81,18 @@ test("Create release", async () => {
   );
 });
 
+test("Dry run labeled event", async () => {
+  context.payload = { action: "labeled" };
+  setInputs({ dry_run: "true" });
+  getNextVersion.mockReturnValueOnce(
+    Promise.resolve()
+  );
+
+  await run();
+
+  expect(getNextVersion).toHaveBeenCalledWith(false);
+})
+
 test("Create prerelease", async () => {
   context.payload = {
     action: "created",


### PR DESCRIPTION
Allow the action to be called with `dry_run` for all pull request events, in addition to `closed`. This will only calculate the next release number and bump level if a version bump should occur.