### PR TITLE
Improved commit filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore IntelliJ IDEA directory
+.idea/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A prerelease can be created from a PR by commenting it with `/prerelease`. This 
 
 If you have existing releases then at least your latest release should follow the `major.minor.patch` format, otherwise the versioning will start from `0.0.1`.
 
-The release title is obtained from the pull request title and the release body also starts with the body message from the PR. Release notes are automatically generated and grouped by commit types. You can opt out of the release note generation with the `release_notes` input variable.
+The release title is obtained from the pull request title and the release body also starts with the body message from the PR. Release notes are automatically generated and grouped by commit types ("test", "docs", "ci" and "chore" commits are excluded). Note also that "fix(review)" commits are excluded from release notes and "fix(deps)" are collected under "Dependencies" header. You can opt out of the release note generation with the `release_notes` input variable.
 
 ## Configuration
 

--- a/src/release-notes.js
+++ b/src/release-notes.js
@@ -10,6 +10,8 @@ const commitHeaders = {
   revert: "Reverts",
 };
 
+const ignoreScopes = ["fix(review)"];
+
 async function createReleaseNotes() {
   const token = core.getInput("github_token", { required: true });
   const octokit = new GitHub(token);
@@ -29,8 +31,9 @@ async function createReleaseNotes() {
     };
     commits.data.forEach(function (item) {
       const parsedCommit = conventionalCommitsParser.sync(item.commit.message);
+      const scopedType = `${parsedCommit.type}(${parsedCommit.scope})`;
       console.log(parsedCommit);
-      if (parsedCommit.type in commitHeaders) {
+      if (parsedCommit.type in commitHeaders && !ignoreScopes.includes(scopedType)) {
         const scope = parsedCommit.scope ? `**${parsedCommit.scope}:** ` : "";
         const message = `- ${scope}${parsedCommit.subject} [${item.sha.slice(
           0,

--- a/src/release-notes.js
+++ b/src/release-notes.js
@@ -6,6 +6,7 @@ const commitHeaders = {
   feat: "Features",
   feature: "Features",
   fix: "Bug Fixes",
+  "fix(deps)": "Dependencies",
   perf: "Performance Improvements",
   revert: "Reverts",
 };
@@ -26,14 +27,20 @@ async function createReleaseNotes() {
     const releaseNotes = {
       Features: [],
       "Bug Fixes": [],
+      Dependencies: [],
       "Performance Improvements": [],
       Reverts: [],
     };
     commits.data.forEach(function (item) {
       const parsedCommit = conventionalCommitsParser.sync(item.commit.message);
-      const scopedType = `${parsedCommit.type}(${parsedCommit.scope})`;
       console.log(parsedCommit);
-      if (parsedCommit.type in commitHeaders && !ignoreScopes.includes(scopedType)) {
+      const scopedType = parsedCommit.scope
+          ? `${parsedCommit.type}(${parsedCommit.scope})`
+          : parsedCommit.type;
+      const header = scopedType in commitHeaders
+          ? commitHeaders[scopedType]
+          : commitHeaders[parsedCommit.type];
+      if (header && !ignoreScopes.includes(scopedType)) {
         const scope = parsedCommit.scope ? `**${parsedCommit.scope}:** ` : "";
         const message = `- ${scope}${parsedCommit.subject} [${item.sha.slice(
           0,
@@ -46,7 +53,7 @@ async function createReleaseNotes() {
           );
         }
         const notes = notesArray.length ? `\n${notesArray.join("\n")}` : "";
-        releaseNotes[commitHeaders[parsedCommit.type]].push(message + notes);
+        releaseNotes[header].push(message + notes);
       }
     });
     const notesArray = [];

--- a/tests/release-notes.test.js
+++ b/tests/release-notes.test.js
@@ -32,6 +32,14 @@ beforeEach(() => {
               commit: { message: "fix(review): shouldn't be listed" },
               sha: "sha7"
             },
+            {
+              commit: { message: "fix(deps): bump package" },
+              sha: "sha8"
+            },
+            {
+              commit: { message: "fix(frontend): UI fixed" },
+              sha: "sha9"
+            },
           ],
         })
       ),
@@ -52,6 +60,12 @@ test("create release notes", async () => {
 <details><summary><strong>Bug Fixes</strong></summary><p>
 
 - bugfix [sha3](undefined)
+- **frontend:** UI fixed [sha9](undefined)
+
+</p></details>
+<details><summary><strong>Dependencies</strong></summary><p>
+
+- **deps:** bump package [sha8](undefined)
 
 </p></details>
 <details><summary><strong>Performance Improvements</strong></summary><p>

--- a/tests/release-notes.test.js
+++ b/tests/release-notes.test.js
@@ -28,6 +28,10 @@ beforeEach(() => {
             },
             { commit: { message: "revert: revert" }, sha: "sha5" },
             { commit: { message: "test: shouldn't be listed" }, sha: "sha6" },
+            {
+              commit: { message: "fix(review): shouldn't be listed" },
+              sha: "sha7"
+            },
           ],
         })
       ),


### PR DESCRIPTION
* Ignores review fixes (`fix(review)`) from release notes
* Collects dependency bumps (`fix(deps)`) under "Dependencies" header in release notes